### PR TITLE
feat: change from composite to succinct proof

### DIFF
--- a/.github/workflows/core-rust.yml
+++ b/.github/workflows/core-rust.yml
@@ -17,8 +17,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install Rust nightly
+      run: rustup install nightly
+
+    - name: Install rustfmt for nightly
+      run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
+
     - name: Run rustfmt
-      run: cargo fmt -- --check
+      run: cargo +nightly fmt -- --check
 
   cargo-sort:
     runs-on: ubuntu-latest

--- a/.github/workflows/core-rust.yml
+++ b/.github/workflows/core-rust.yml
@@ -36,7 +36,7 @@ jobs:
       run: cargo install cargo-sort
 
     - name: Run cargo sort
-      run: cargo sort --grouped --check
+      run: cargo sort --workspace --grouped --check
 
   build:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ edition = "2024"
 
 [workspace.dependencies]
 ethereum_ssz = "0.8.2"
-tracing = "0.1.40"
 ream-consensus = { git = "https://github.com/ReamLabs/ream", package = "ream-consensus" }
+tracing = "0.1.40"
 
 [patch.crates-io]
 ethereum_hashing = { git = "https://github.com/ReamLabs/ethereum_hashing" }

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -8,14 +8,14 @@ name = "consenzero-script"
 path = "src/bin/main.rs"
 
 [dependencies]
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-serde = { version = "1.0.200", default-features = false, features = ["derive"] }
-derive_more = { version = "2.0.1", features = ["full"] }
 clap = { version = "4.0", features = ["derive", "env"] }
-hex = "0.4.3"
+derive_more = { version = "2.0.1", features = ["full"] }
 dotenv = "0.15.0"
+hex = "0.4.3"
 methods = { path = "../methods" }
 risc0-zkvm = { version = "2.0.1" }
+serde = { version = "1.0.200", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/host/src/bin/main.rs
+++ b/host/src/bin/main.rs
@@ -126,7 +126,9 @@ fn main() {
 
         // Proof information by proving the specified ELF binary.
         // This struct contains the receipt along with statistics about execution of the guest
-        let prove_info = prover.prove_with_opts(env, CONSENSUS_STF_ELF, &opts).unwrap();
+        let prove_info = prover
+            .prove_with_opts(env, CONSENSUS_STF_ELF, &opts)
+            .unwrap();
 
         info!("Proving complete");
 
@@ -135,7 +137,10 @@ fn main() {
 
         info!("Seal size: {:#?}", receipt.seal_size());
         info!("Receipt: {:#?}", receipt);
-        info!("New state root: {:?}", receipt.journal.decode::<tree_hash::Hash256>().unwrap());
+        info!(
+            "New state root: {:?}",
+            receipt.journal.decode::<tree_hash::Hash256>().unwrap()
+        );
 
         receipt.verify(CONSENSUS_STF_ID).unwrap();
         info!("Verfication complete");

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 ethereum_ssz = { workspace = true }
+serde = { version = "1.0.200", default-features = false, features = ["derive"] }
 snap = "1.1.1"
 tracing = { workspace = true }
-serde = { version = "1.0.200", default-features = false, features = ["derive"] }
 
 # ReamBeaconState
 alloy-primitives = { version = "0.8", features = ['serde'] }

--- a/methods/Cargo.toml
+++ b/methods/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "methods"
-version = "0.1.0"
 edition = "2024"
+version = "0.1.0"
 
 [build-dependencies]
 risc0-build = { version = "2.0.1" }


### PR DESCRIPTION
Instead of generating a 6.4 MB composite proof, reconfigure r0vm to generate 0.22 MB succinct proof

Composite proof

```
2025-05-28T06:30:36.982606Z  INFO risc0_zkvm::host::server::exec::executor: execution time: 881.564583ms
2025-05-28T07:13:54.355292Z  INFO consenzero_script: Proving complete
2025-05-28T07:13:54.355307Z  INFO consenzero_script: Seal size: 6464472
```

Succinct proof

```
2025-05-28T07:17:30.682278Z  INFO risc0_zkvm::host::server::exec::executor: execution time: 883.29975ms
2025-05-28T08:02:55.430568Z  INFO consenzero_script: Proving complete
2025-05-28T08:02:55.430581Z  INFO consenzero_script: Seal size: 222668
```